### PR TITLE
Feature - Enforce immutable interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor/
 .idea/
+composer.phar
+

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMPOSER_PHAR_CHECKSUM = 4e4c1cd74b54a26618699f3190e6f5fc63bb308b13fa660f71f2a2d
 test: vendor
 	vendor/bin/phpunit
 
-vendor:
+vendor: composer.phar
 	php composer.phar install
 
 composer.phar: Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
+COMPOSER_PHAR_VERSION = 1.8.5
+COMPOSER_PHAR_CHECKSUM = 4e4c1cd74b54a26618699f3190e6f5fc63bb308b13fa660f71f2a2df047c0e17
+
 test: vendor
 	vendor/bin/phpunit
 
 vendor:
-	composer install
+	php composer.phar install
+
+composer.phar: Makefile
+	curl https://getcomposer.org/download/$(COMPOSER_PHAR_VERSION)/composer.phar -o composer.phar.download
+	echo "$(COMPOSER_PHAR_CHECKSUM)  composer.phar.download" | shasum -a 256 -c
+	mv composer.phar.download -f composer.phar

--- a/src/Model/Block.php
+++ b/src/Model/Block.php
@@ -35,7 +35,7 @@ class Block implements Node
 
         $this->type = $type;
         $this->data = $data;
-        $this->nodes = $nodes;
+        $this->nodes = array_values($nodes);
     }
 
     /**

--- a/src/Model/Document.php
+++ b/src/Model/Document.php
@@ -2,6 +2,8 @@
 
 namespace Prezly\Slate\Model;
 
+use InvalidArgumentException;
+
 class Document implements Node
 {
     /** @var Block[] */
@@ -11,14 +13,21 @@ class Document implements Node
     private $data = [];
 
     /**
-     * @param \Prezly\Slate\Model\Block[] $nodes
+     * @param Block[] $nodes
      * @param array $data
      */
     public function __construct(array $nodes = [], array $data = [])
     {
         foreach ($nodes as $node) {
-            $this->addNode($node);
+            if (! $node instanceof Block) {
+                throw new InvalidArgumentException(sprintf(
+                    'Document can only have %s as child nodes. %s given.',
+                    Block::class,
+                    is_object($node) ? get_class($node) : gettype($node)
+                ));
+            }
         }
+        $this->nodes = $nodes;
         $this->data = $data;
     }
 
@@ -32,12 +41,6 @@ class Document implements Node
         return $this->nodes;
     }
 
-    public function addNode(Block $block): Document
-    {
-        $this->nodes[] = $block;
-        return $this;
-    }
-
     /**
      * @return array
      */
@@ -47,11 +50,21 @@ class Document implements Node
     }
 
     /**
-     * @param array $data
+     * @param Block[] $nodes
+     * @return Document New Document instance
      */
-    public function setData(array $data): void
+    public function withNodes(array $nodes): Document
     {
-        $this->data = $data;
+        return new self($nodes, $this->data);
+    }
+
+    /**
+     * @param array $data
+     * @return Document New Document instance
+     */
+    public function withData(array $data): Document
+    {
+        return new self($this->nodes, $data);
     }
 
     public function getText(): string

--- a/src/Model/Document.php
+++ b/src/Model/Document.php
@@ -27,7 +27,7 @@ class Document implements Node
                 ));
             }
         }
-        $this->nodes = $nodes;
+        $this->nodes = array_values($nodes);
         $this->data = $data;
     }
 

--- a/src/Model/Inline.php
+++ b/src/Model/Inline.php
@@ -25,7 +25,7 @@ class Inline implements Node
         foreach ($nodes as $node) {
             if (! $node instanceof Node && ! $node instanceof Text) {
                 throw new InvalidArgumentException(sprintf(
-                    'Block can only have %s or %s as child nodes. %s given.',
+                    'Inline can only have %s or %s as child nodes. %s given.',
                     Node::class,
                     Text::class,
                     is_object($node) ? get_class($node) : gettype($node)

--- a/src/Model/Inline.php
+++ b/src/Model/Inline.php
@@ -35,7 +35,7 @@ class Inline implements Node
 
         $this->type = $type;
         $this->data = $data;
-        $this->nodes = $nodes;
+        $this->nodes = array_values($nodes);
     }
 
     public function getType(): string

--- a/src/Model/Leaf.php
+++ b/src/Model/Leaf.php
@@ -2,6 +2,8 @@
 
 namespace Prezly\Slate\Model;
 
+use InvalidArgumentException;
+
 class Leaf implements Entity
 {
     /** @var string */
@@ -12,24 +14,27 @@ class Leaf implements Entity
 
     /**
      * @param string $text
-     * @param \Prezly\Slate\Model\Mark[] $marks
+     * @param Mark[] $marks
      */
     public function __construct(string $text, array $marks = [])
     {
-        $this->text = $text;
         foreach ($marks as $mark) {
-            $this->addMark($mark);
+            if (! $mark instanceof Mark) {
+                throw new InvalidArgumentException(sprintf(
+                    'Leaf can only have %s as child marks. %s given.',
+                    Mark::class,
+                    is_object($mark) ? get_class($mark) : gettype($mark)
+                ));
+            }
         }
+
+        $this->text = $text;
+        $this->marks = $marks;
     }
 
     public function getText(): ?string
     {
         return $this->text;
-    }
-
-    public function setText(string $text): void
-    {
-        $this->text = $text;
     }
 
     /**
@@ -40,21 +45,22 @@ class Leaf implements Entity
         return $this->marks;
     }
 
-    public function addMark(Mark $mark): Leaf
+    /**
+     * @param string $text
+     * @return Leaf new instance
+     */
+    public function withText(string $text): Leaf
     {
-        $this->marks[] = $mark;
-        return $this;
+        return new self($text, $this->marks);
     }
 
     /**
      * @param Mark[] $marks
+     * @return Leaf new instance
      */
-    public function setMarks(array $marks): void
+    public function withMarks(array $marks): Leaf
     {
-        $this->marks = [];
-        foreach ($marks as $mark) {
-            $this->addMark($mark);
-        }
+        return new self($this->text, $marks);
     }
 
     public function jsonSerialize()

--- a/src/Model/Leaf.php
+++ b/src/Model/Leaf.php
@@ -29,7 +29,7 @@ class Leaf implements Entity
         }
 
         $this->text = $text;
-        $this->marks = $marks;
+        $this->marks = array_values($marks);
     }
 
     public function getText(): string

--- a/src/Model/Mark.php
+++ b/src/Model/Mark.php
@@ -21,19 +21,27 @@ class Mark implements Entity
         return $this->type;
     }
 
-    public function setType(string $type): void
-    {
-        $this->type = $type;
-    }
-
     public function getData(): array
     {
         return $this->data;
     }
 
-    public function setData(array $data): void
+    /**
+     * @param string $type
+     * @return Mark new instance
+     */
+    public function withType(string $type): Mark
     {
-        $this->data = $data;
+        return new self($type, $this->data);
+    }
+
+    /**
+     * @param array $data
+     * @return Mark new instance
+     */
+    public function withData(array $data): Mark
+    {
+        return new self($this->type, $data);
     }
 
     public function jsonSerialize()

--- a/src/Model/Text.php
+++ b/src/Model/Text.php
@@ -24,7 +24,7 @@ class Text implements Entity
             }
         }
 
-        $this->leaves = $leaves;
+        $this->leaves = array_values($leaves);
     }
 
     /**

--- a/src/Model/Text.php
+++ b/src/Model/Text.php
@@ -2,33 +2,46 @@
 
 namespace Prezly\Slate\Model;
 
+use InvalidArgumentException;
+
 class Text implements Entity
 {
     /** @var Leaf[] */
     private $leaves = [];
 
     /**
-     * @param \Prezly\Slate\Model\Leaf[] $leaves
+     * @param Leaf[] $leaves
      */
     public function __construct(array $leaves = [])
     {
         foreach ($leaves as $leaf) {
-            $this->addLeaf($leaf);
+            if (! $leaf instanceof Leaf) {
+                throw new InvalidArgumentException(sprintf(
+                    'Text can only have %s as leaves. %s given.',
+                    Leaf::class,
+                    is_object($leaf) ? get_class($leaf) : gettype($leaf)
+                ));
+            }
         }
+
+        $this->leaves = $leaves;
     }
 
     /**
-     * @return \Prezly\Slate\Model\Leaf[]
+     * @return Leaf[]
      */
     public function getLeaves(): array
     {
         return $this->leaves;
     }
 
-    public function addLeaf(Leaf $leaf): Text
+    /**
+     * @param array $leaves
+     * @return Text
+     */
+    public function withLeaves(array $leaves): self
     {
-        $this->leaves[] = $leaf;
-        return $this;
+        return new self($leaves);
     }
 
     public function getText(): string

--- a/src/Model/Value.php
+++ b/src/Model/Value.php
@@ -12,14 +12,21 @@ class Value implements Entity
         $this->document = $document;
     }
 
+    /**
+     * @return Document
+     */
     public function getDocument(): Document
     {
         return $this->document;
     }
 
-    public function setDocument(Document $document): void
+    /**
+     * @param Document $document
+     * @return Value new instance
+     */
+    public function withDocument(Document $document): Value
     {
-        $this->document = $document;
+        return new self($document);
     }
 
     public function jsonSerialize()


### PR DESCRIPTION
Fixes #19.
Related to #22 

- Update the model to drop deprecated mutable setters.
- Instead of `addXxx()` and `setXxx()` methods we now have `withXxx()` that are always returning a new instance. 

---------------

List of BC changes:

- `Value::setDocument()` has been dropped
- `Document::setData()` has been dropped
- `Document::addNode()` has been dropped
- `Block::setType()` has been dropped
- `Block::setData()` has been dropped
- `Block::addNode()` has been dropped
- `Text::addLeaf()` has been dropped
- `Inline::setType()` has been dropped
- `Inline::setData()` has been dropped
- `Inline::addNode()` has been dropped
- `Mark::setType()` has been dropped
- `Mark::setData()` has been dropped
- `Leaf::setText()` has been dropped
- `Leaf::setMarks()` has been dropped
- `Leaf::addMarks()` has been dropped

Instead we now have:

- `Value::withDocument()`
- `Document::withData()` 
- `Document::withNodes()`
- `Block::withType()`
- `Block::withData()`
- `Block::withNodes()`
- `Text::withLeaves()`
- `Inline::withType()`
- `Inline::withData()`
- `Inline::withNodes()`
- `Mark::withType()`
- `Mark::withData()`
- `Leaf::withText()`
- `Leaf::withMarks()`
- `Leaf::withMarks()`