### PR TITLE
Refactor - Unify constructor arguments order

### DIFF
--- a/src/Model/Block.php
+++ b/src/Model/Block.php
@@ -15,10 +15,10 @@ class Block implements Node
 
     /**
      * @param string $type
-     * @param array $data
      * @param Node[]|Text[] $nodes
+     * @param array $data
      */
-    public function __construct(string $type, array $data = [], array $nodes = [])
+    public function __construct(string $type, array $nodes = [], array $data = [])
     {
         $this->type = $type;
         $this->data = $data;

--- a/src/Model/Inline.php
+++ b/src/Model/Inline.php
@@ -15,10 +15,10 @@ class Inline implements Node
 
     /**
      * @param string $type
-     * @param array $data
      * @param Node[]|Text[] $nodes
+     * @param array $data
      */
-    public function __construct(string $type, array $data = [], array $nodes = [])
+    public function __construct(string $type, array $nodes = [], array $data = [])
     {
         $this->type = $type;
         $this->data = $data;

--- a/src/Unserializer.php
+++ b/src/Unserializer.php
@@ -115,7 +115,7 @@ class Unserializer
             $nodes[] = $this->createObject($node);
         }
 
-        return new Block($object->type, (array) $object->data, $nodes);
+        return new Block($object->type, $nodes, (array) $object->data);
     }
 
     private function createInline(stdClass $object): Inline
@@ -127,7 +127,7 @@ class Unserializer
             $nodes[] = $this->createObject($node);
         }
 
-        return new Inline($object->type, (array) $object->data, $nodes);
+        return new Inline($object->type, $nodes, (array) $object->data);
     }
 
     private function createText(stdClass $object): Text


### PR DESCRIPTION
`$nodes` is now always preceding `$data`. Just like in `Document`.

BC-breaking changes:

- `Block` constructor arguments changed: `($type, $data, $nodes)` &rarr; `($type, $nodes, $data)`
- `Inline` constructor arguments changed: `($type, $data, $nodes)` &rarr; `($type, $nodes, $data)`