### PR TITLE
Feature - Immutability (2.x to 3.x transition)

### DIFF
--- a/src/Model/Block.php
+++ b/src/Model/Block.php
@@ -47,6 +47,8 @@ class Block implements Node
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withType() instead.
+     * @see withType()
      * @param string $type
      */
     public function setType(string $type): void
@@ -63,6 +65,8 @@ class Block implements Node
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withData() instead.
+     * @see withData()
      * @param array $data
      */
     public function setData(array $data): void
@@ -79,6 +83,8 @@ class Block implements Node
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withNodes() instead.
+     * @see withNodes()
      * @param Node|Text $node
      * @return Block
      */

--- a/src/Model/Block.php
+++ b/src/Model/Block.php
@@ -2,6 +2,8 @@
 
 namespace Prezly\Slate\Model;
 
+use InvalidArgumentException;
+
 class Block implements Node
 {
     /** @var string */
@@ -20,29 +22,49 @@ class Block implements Node
      */
     public function __construct(string $type, array $data = [], array $nodes = [])
     {
+        foreach ($nodes as $node) {
+            if (! $node instanceof Node && ! $node instanceof Text) {
+                throw new InvalidArgumentException(sprintf(
+                    'Block can only have %s or %s as child nodes. %s given.',
+                    Node::class,
+                    Text::class,
+                    is_object($node) ? get_class($node) : gettype($node)
+                ));
+            }
+        }
+
         $this->type = $type;
         $this->data = $data;
-
-        foreach ($nodes as $node) {
-            $this->addNode($node);
-        }
+        $this->nodes = $nodes;
     }
 
+    /**
+     * @return string
+     */
     public function getType(): string
     {
         return $this->type;
     }
 
+    /**
+     * @param string $type
+     */
     public function setType(string $type): void
     {
         $this->type = $type;
     }
 
+    /**
+     * @return array
+     */
     public function getData(): array
     {
         return $this->data;
     }
 
+    /**
+     * @param array $data
+     */
     public function setData(array $data): void
     {
         $this->data = $data;
@@ -70,6 +92,36 @@ class Block implements Node
         throw new \InvalidArgumentException('Block can only have Node and Text child nodes');
     }
 
+    /**
+     * @param string $type
+     * @return Block New instance
+     */
+    public function withType(string $type): Block
+    {
+        return new self($type, $this->data, $this->nodes);
+    }
+
+    /**
+     * @param array $data
+     * @return Block New instance
+     */
+    public function withData(array $data): Block
+    {
+        return new self($this->type, $data, $this->nodes);
+    }
+
+    /**
+     * @param Node[]|Text[] $nodes
+     * @return Block New instance
+     */
+    public function withNodes(array $nodes): Block
+    {
+        return new self($this->type, $this->data, $nodes);
+    }
+
+    /**
+     * @return string
+     */
     public function getText(): string
     {
         $text = '';

--- a/src/Model/Document.php
+++ b/src/Model/Document.php
@@ -2,6 +2,8 @@
 
 namespace Prezly\Slate\Model;
 
+use InvalidArgumentException;
+
 class Document implements Node
 {
     /** @var Block[] */
@@ -11,14 +13,21 @@ class Document implements Node
     private $data = [];
 
     /**
-     * @param \Prezly\Slate\Model\Block[] $nodes
+     * @param Block[] $nodes
      * @param array $data
      */
     public function __construct(array $nodes = [], array $data = [])
     {
         foreach ($nodes as $node) {
-            $this->addNode($node);
+            if (! $node instanceof Block) {
+                throw new InvalidArgumentException(sprintf(
+                    'Document can only have %s as child nodes. %s given.',
+                    Block::class,
+                    is_object($node) ? get_class($node) : gettype($node)
+                ));
+            }
         }
+        $this->nodes = $nodes;
         $this->data = $data;
     }
 
@@ -32,6 +41,10 @@ class Document implements Node
         return $this->nodes;
     }
 
+    /**
+     * @param Block $block
+     * @return Document
+     */
     public function addNode(Block $block): Document
     {
         $this->nodes[] = $block;
@@ -54,6 +67,27 @@ class Document implements Node
         $this->data = $data;
     }
 
+    /**
+     * @param Block[] $nodes
+     * @return Document New Document instance
+     */
+    public function withNodes(array $nodes): Document
+    {
+        return new self($nodes, $this->data);
+    }
+
+    /**
+     * @param array $data
+     * @return Document New Document instance
+     */
+    public function withData(array $data): Document
+    {
+        return new self($this->nodes, $data);
+    }
+
+    /**
+     * @return string
+     */
     public function getText(): string
     {
         $text = '';

--- a/src/Model/Document.php
+++ b/src/Model/Document.php
@@ -42,6 +42,8 @@ class Document implements Node
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withNodes() instead.
+     * @see withNodes()
      * @param Block $block
      * @return Document
      */
@@ -60,6 +62,8 @@ class Document implements Node
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withData() instead.
+     * @see withData()
      * @param array $data
      */
     public function setData(array $data): void

--- a/src/Model/Inline.php
+++ b/src/Model/Inline.php
@@ -2,6 +2,8 @@
 
 namespace Prezly\Slate\Model;
 
+use InvalidArgumentException;
+
 class Inline implements Node
 {
     /** @var string */
@@ -20,29 +22,49 @@ class Inline implements Node
      */
     public function __construct(string $type, array $data = [], array $nodes = [])
     {
+        foreach ($nodes as $node) {
+            if (! $node instanceof Node && ! $node instanceof Text) {
+                throw new InvalidArgumentException(sprintf(
+                    'Block can only have %s or %s as child nodes. %s given.',
+                    Node::class,
+                    Text::class,
+                    is_object($node) ? get_class($node) : gettype($node)
+                ));
+            }
+        }
+
         $this->type = $type;
         $this->data = $data;
-
-        foreach ($nodes as $node) {
-            $this->addNode($node);
-        }
+        $this->nodes = $nodes;
     }
 
+    /**
+     * @return string
+     */
     public function getType(): string
     {
         return $this->type;
     }
 
+    /**
+     * @param string $type
+     */
     public function setType(string $type): void
     {
         $this->type = $type;
     }
 
+    /**
+     * @return array
+     */
     public function getData(): array
     {
         return $this->data;
     }
 
+    /**
+     * @param array $data
+     */
     public function setData(array $data): void
     {
         $this->data = $data;
@@ -58,7 +80,7 @@ class Inline implements Node
 
     /**
      * @param Node|Text $node
-     * @return Inline
+     * @return Inline current instance (for method chaining)
      */
     public function addNode(Entity $node): Inline
     {
@@ -68,6 +90,33 @@ class Inline implements Node
         }
 
         throw new \InvalidArgumentException('Inline can only have Node and Text child nodes');
+    }
+
+    /**
+     * @param string $type
+     * @return Inline New instance
+     */
+    public function withType(string $type): self
+    {
+        return new self($type, $this->data, $this->nodes);
+    }
+
+    /**
+     * @param array $data
+     * @return Inline New instance
+     */
+    public function withData(array $data): self
+    {
+        return new self($this->type, $data, $this->nodes);
+    }
+
+    /**
+     * @param Node[]|Text[] $nodes
+     * @return Inline New instance
+     */
+    public function withNodes(array $nodes): Inline
+    {
+        return new self($this->type, $this->data, $nodes);
     }
 
     public function getText(): string

--- a/src/Model/Inline.php
+++ b/src/Model/Inline.php
@@ -47,6 +47,8 @@ class Inline implements Node
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withType() instead.
+     * @see withType()
      * @param string $type
      */
     public function setType(string $type): void
@@ -63,6 +65,8 @@ class Inline implements Node
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withData() instead.
+     * @see withData()
      * @param array $data
      */
     public function setData(array $data): void
@@ -79,6 +83,8 @@ class Inline implements Node
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withNodes() instead.
+     * @see withNodes()
      * @param Node|Text $node
      * @return Inline current instance (for method chaining)
      */

--- a/src/Model/Leaf.php
+++ b/src/Model/Leaf.php
@@ -41,6 +41,8 @@ class Leaf implements Entity
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withText() instead.
+     * @see withText()
      * @param string $text
      */
     public function setText(string $text): void
@@ -56,7 +58,9 @@ class Leaf implements Entity
         return $this->marks;
     }
 
-    /**\
+    /**
+     * @deprecated Deprecated in favor of immutable API. Use withMarks() instead.
+     * @see withMarks()
      * @param Mark $mark
      * @return Leaf current instance (for method chaining)
      */
@@ -67,6 +71,8 @@ class Leaf implements Entity
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withMarks() instead.
+     * @see withMarks()
      * @param Mark[] $marks
      */
     public function setMarks(array $marks): void

--- a/src/Model/Leaf.php
+++ b/src/Model/Leaf.php
@@ -2,6 +2,8 @@
 
 namespace Prezly\Slate\Model;
 
+use InvalidArgumentException;
+
 class Leaf implements Entity
 {
     /** @var string */
@@ -12,21 +14,35 @@ class Leaf implements Entity
 
     /**
      * @param string $text
-     * @param \Prezly\Slate\Model\Mark[] $marks
+     * @param Mark[] $marks
      */
     public function __construct(string $text, array $marks = [])
     {
-        $this->text = $text;
         foreach ($marks as $mark) {
-            $this->addMark($mark);
+            if (! $mark instanceof Mark) {
+                throw new InvalidArgumentException(sprintf(
+                    'Leaf can only have %s as child marks. %s given.',
+                    Mark::class,
+                    is_object($mark) ? get_class($mark) : gettype($mark)
+                ));
+            }
         }
+
+        $this->text = $text;
+        $this->marks = $marks;
     }
 
+    /**
+     * @return string|null
+     */
     public function getText(): ?string
     {
         return $this->text;
     }
 
+    /**
+     * @param string $text
+     */
     public function setText(string $text): void
     {
         $this->text = $text;
@@ -40,6 +56,10 @@ class Leaf implements Entity
         return $this->marks;
     }
 
+    /**\
+     * @param Mark $mark
+     * @return Leaf current instance (for method chaining)
+     */
     public function addMark(Mark $mark): Leaf
     {
         $this->marks[] = $mark;
@@ -55,6 +75,24 @@ class Leaf implements Entity
         foreach ($marks as $mark) {
             $this->addMark($mark);
         }
+    }
+
+    /**
+     * @param string $text
+     * @return Leaf New instance
+     */
+    public function withText(string $text): Leaf
+    {
+        return new self($text, $this->marks);
+    }
+
+    /**
+     * @param Mark[] $marks
+     * @return Leaf New instance
+     */
+    public function withMarks(array $marks): Leaf
+    {
+        return new self($this->text, $marks);
     }
 
     public function jsonSerialize()

--- a/src/Model/Mark.php
+++ b/src/Model/Mark.php
@@ -25,6 +25,8 @@ class Mark implements Entity
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withType() instead.
+     * @see withType()
      * @param string $type
      */
     public function setType(string $type): void
@@ -41,6 +43,8 @@ class Mark implements Entity
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withData() instead.
+     * @see withData()
      * @param array $data
      */
     public function setData(array $data): void

--- a/src/Model/Mark.php
+++ b/src/Model/Mark.php
@@ -16,24 +16,54 @@ class Mark implements Entity
         $this->data = $data;
     }
 
+    /**
+     * @return string
+     */
     public function getType(): string
     {
         return $this->type;
     }
 
+    /**
+     * @param string $type
+     */
     public function setType(string $type): void
     {
         $this->type = $type;
     }
 
+    /**
+     * @return array
+     */
     public function getData(): array
     {
         return $this->data;
     }
 
+    /**
+     * @param array $data
+     */
     public function setData(array $data): void
     {
         $this->data = $data;
+    }
+
+    /**
+     * @param string $type
+     * @return Mark New instance
+     */
+    public function withType(string $type): Mark
+    {
+        return new self($type, $this->data);
+    }
+
+    /**
+     * @param array $data
+     * @return Mark New instance
+     */
+    public function withData(array $data): Mark
+    {
+        return new self($this->type, $data);
     }
 
     public function jsonSerialize()

--- a/src/Model/Text.php
+++ b/src/Model/Text.php
@@ -2,33 +2,56 @@
 
 namespace Prezly\Slate\Model;
 
+use InvalidArgumentException;
+
 class Text implements Entity
 {
     /** @var Leaf[] */
     private $leaves = [];
 
     /**
-     * @param \Prezly\Slate\Model\Leaf[] $leaves
+     * @param Leaf[] $leaves
      */
     public function __construct(array $leaves = [])
     {
         foreach ($leaves as $leaf) {
-            $this->addLeaf($leaf);
+            if (! $leaf instanceof Leaf) {
+                throw new InvalidArgumentException(sprintf(
+                    'Text can only have %s as leaves. %s given.',
+                    Leaf::class,
+                    is_object($leaf) ? get_class($leaf) : gettype($leaf)
+                ));
+            }
         }
+
+        $this->leaves = $leaves;
     }
 
     /**
-     * @return \Prezly\Slate\Model\Leaf[]
+     * @return Leaf[]
      */
     public function getLeaves(): array
     {
         return $this->leaves;
     }
 
+    /**
+     * @param Leaf $leaf
+     * @return Text current instance (for method chaining)
+     */
     public function addLeaf(Leaf $leaf): Text
     {
         $this->leaves[] = $leaf;
         return $this;
+    }
+
+    /**
+     * @param Leaf[] $leaves
+     * @return Text New instance
+     */
+    public function withLeaves(array $leaves): self
+    {
+        return new self($leaves);
     }
 
     public function getText(): string

--- a/src/Model/Text.php
+++ b/src/Model/Text.php
@@ -36,6 +36,8 @@ class Text implements Entity
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withLeaves() instead.
+     * @see withLeaves()
      * @param Leaf $leaf
      * @return Text current instance (for method chaining)
      */

--- a/src/Model/Value.php
+++ b/src/Model/Value.php
@@ -12,14 +12,29 @@ class Value implements Entity
         $this->document = $document;
     }
 
+    /**
+     * @return Document
+     */
     public function getDocument(): Document
     {
         return $this->document;
     }
 
+    /**
+     * @param Document $document
+     */
     public function setDocument(Document $document): void
     {
         $this->document = $document;
+    }
+
+    /**
+     * @param Document $document
+     * @return Value New instance
+     */
+    public function withDocument(Document $document): Value
+    {
+        return new self($document);
     }
 
     public function jsonSerialize()

--- a/src/Model/Value.php
+++ b/src/Model/Value.php
@@ -21,6 +21,8 @@ class Value implements Entity
     }
 
     /**
+     * @deprecated Deprecated in favor of immutable API. Use withDocument() instead.
+     * @see withDocument()
      * @param Document $document
      */
     public function setDocument(Document $document): void

--- a/tests/BlockTest.php
+++ b/tests/BlockTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Prezly\Slate\Tests;
+
+use Prezly\Slate\Model\Block;
+use Prezly\Slate\Model\Inline;
+
+class BlockTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_type()
+    {
+        $type_a = 'block_a';
+        $type_b = 'block_b';
+        $nodes = [new Inline('x')];
+        $data = ['data' => 'x'];
+
+        $block_a = new Block($type_a, $data, $nodes);
+        $block_b = $block_a->withType($type_b);
+
+        $this->assertNotSame($block_a, $block_b);
+        $this->assertSame($type_a, $block_a->getType());
+        $this->assertSame($type_b, $block_b->getType());
+        $this->assertSame($nodes, $block_a->getNodes());
+        $this->assertSame($nodes, $block_b->getNodes());
+        $this->assertSame($data, $block_a->getData());
+        $this->assertSame($data, $block_b->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_nodes()
+    {
+        $type = 'block_a';
+        $nodes_a = [new Inline('a')];
+        $nodes_b = [new Inline('b')];
+        $data = ['data' => 'x'];
+
+        $block_a = new Block($type, $data, $nodes_a);
+        $block_b = $block_a->withNodes($nodes_b);
+
+        $this->assertNotSame($block_a, $block_b);
+        $this->assertSame($type, $block_a->getType());
+        $this->assertSame($type, $block_b->getType());
+        $this->assertSame($nodes_a, $block_a->getNodes());
+        $this->assertSame($nodes_b, $block_b->getNodes());
+        $this->assertSame($data, $block_a->getData());
+        $this->assertSame($data, $block_b->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_data()
+    {
+        $type = 'block_a';
+        $nodes = [new Inline('x')];
+        $data_a = ['data' => 'a'];
+        $data_b = ['data' => 'b'];
+
+        $block_a = new Block($type, $data_a, $nodes);
+        $block_b = $block_a->withData($data_b);
+
+        $this->assertNotSame($block_a, $block_b);
+        $this->assertSame($type, $block_a->getType());
+        $this->assertSame($type, $block_b->getType());
+        $this->assertSame($nodes, $block_a->getNodes());
+        $this->assertSame($nodes, $block_b->getNodes());
+        $this->assertSame($data_a, $block_a->getData());
+        $this->assertSame($data_b, $block_b->getData());
+    }
+}

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -2,6 +2,9 @@
 
 namespace Prezly\Slate\Tests;
 
+use Prezly\Slate\Model\Block;
+use Prezly\Slate\Model\Document;
+
 class DocumentTest extends TestCase
 {
     /**
@@ -15,5 +18,45 @@ class DocumentTest extends TestCase
             "I'd like to introduce you to a very important person!",
             $document->getText()
         );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_nodes()
+    {
+        $data = ['data' => 'x'];
+
+        $nodes_a = [new Block('a')];
+        $nodes_b = [new Block('b')];
+
+        $document_a = new Document($nodes_a, $data);
+        $document_b = $document_a->withNodes($nodes_b);
+
+        $this->assertNotSame($document_a, $document_b);
+        $this->assertSame($nodes_a, $document_a->getNodes());
+        $this->assertSame($nodes_b, $document_b->getNodes());
+        $this->assertSame($data, $document_a->getData());
+        $this->assertSame($data, $document_b->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_data()
+    {
+        $data_a = ['data' => 'a'];
+        $data_b = ['data' => 'b'];
+
+        $nodes = [new Block('x')];
+
+        $document_a = new Document($nodes, $data_a);
+        $document_b = $document_a->withData($data_b);
+
+        $this->assertNotSame($document_a, $document_b);
+        $this->assertSame($nodes, $document_a->getNodes());
+        $this->assertSame($nodes, $document_b->getNodes());
+        $this->assertSame($data_a, $document_a->getData());
+        $this->assertSame($data_b, $document_b->getData());
     }
 }

--- a/tests/InlineTest.php
+++ b/tests/InlineTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Prezly\Slate\Tests;
+
+use Prezly\Slate\Model\Block;
+use Prezly\Slate\Model\Inline;
+
+class InlineTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_type()
+    {
+        $type_a = 'inline_a';
+        $type_b = 'inline_b';
+        $nodes = [new Block('x')];
+        $data = ['data' => 'x'];
+
+        $inline_a = new Inline($type_a, $data, $nodes);
+        $inline_b = $inline_a->withType($type_b);
+
+        $this->assertNotSame($inline_a, $inline_b);
+        $this->assertSame($type_a, $inline_a->getType());
+        $this->assertSame($type_b, $inline_b->getType());
+        $this->assertSame($nodes, $inline_a->getNodes());
+        $this->assertSame($nodes, $inline_b->getNodes());
+        $this->assertSame($data, $inline_a->getData());
+        $this->assertSame($data, $inline_b->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_nodes()
+    {
+        $type = 'inline_a';
+        $nodes_a = [new Block('a')];
+        $nodes_b = [new Block('b')];
+        $data = ['data' => 'x'];
+
+        $inline_a = new Inline($type, $data, $nodes_a);
+        $inline_b = $inline_a->withNodes($nodes_b);
+
+        $this->assertNotSame($inline_a, $inline_b);
+        $this->assertSame($type, $inline_a->getType());
+        $this->assertSame($type, $inline_b->getType());
+        $this->assertSame($nodes_a, $inline_a->getNodes());
+        $this->assertSame($nodes_b, $inline_b->getNodes());
+        $this->assertSame($data, $inline_a->getData());
+        $this->assertSame($data, $inline_b->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_data()
+    {
+        $type = 'inline_a';
+        $nodes = [new Block('x')];
+        $data_a = ['data' => 'a'];
+        $data_b = ['data' => 'b'];
+
+        $inline_a = new Inline($type, $data_a, $nodes);
+        $inline_b = $inline_a->withData($data_b);
+
+        $this->assertNotSame($inline_a, $inline_b);
+        $this->assertSame($type, $inline_a->getType());
+        $this->assertSame($type, $inline_b->getType());
+        $this->assertSame($nodes, $inline_a->getNodes());
+        $this->assertSame($nodes, $inline_b->getNodes());
+        $this->assertSame($data_a, $inline_a->getData());
+        $this->assertSame($data_b, $inline_b->getData());
+    }
+}

--- a/tests/LeafTest.php
+++ b/tests/LeafTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace Prezly\Slate\Tests;
+
+use Prezly\Slate\Model\Leaf;
+use Prezly\Slate\Model\Mark;
+
+class LeafTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_text()
+    {
+        $text_a = 'aaa aa aa';
+        $text_b = 'bbb bb bb';
+        $marks = [new Mark('x')];
+
+        $leaf_a = new Leaf($text_a, $marks);
+        $leaf_b = $leaf_a->withText($text_b);
+
+        $this->assertNotSame($leaf_a, $leaf_b);
+        $this->assertSame($text_a, $leaf_a->getText());
+        $this->assertSame($text_b, $leaf_b->getText());
+        $this->assertSame($marks, $leaf_a->getMarks());
+        $this->assertSame($marks, $leaf_b->getMarks());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_marks()
+    {
+        $text = 'xxx xx xx';
+        $marks_a = [new Mark('a')];
+        $marks_b = [new Mark('b')];
+
+        $leaf_a = new Leaf($text, $marks_a);
+        $leaf_b = $leaf_a->withMarks($marks_b);
+
+        $this->assertNotSame($leaf_a, $leaf_b);
+        $this->assertSame($text, $leaf_a->getText());
+        $this->assertSame($text, $leaf_b->getText());
+        $this->assertSame($marks_a, $leaf_a->getMarks());
+        $this->assertSame($marks_b, $leaf_b->getMarks());
+    }
+}

--- a/tests/MarkTest.php
+++ b/tests/MarkTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace Prezly\Slate\Tests;
+
+use Prezly\Slate\Model\Mark;
+
+class MarkTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_type()
+    {
+        $type_a = 'mark_a';
+        $type_b = 'mark_b';
+        $data = ['data' => 'x'];
+
+        $mark_a = new Mark($type_a, $data);
+        $mark_b = $mark_a->withType($type_b);
+
+        $this->assertNotSame($mark_a, $mark_b);
+        $this->assertSame($type_a, $mark_a->getType());
+        $this->assertSame($type_b, $mark_b->getType());
+        $this->assertSame($data, $mark_a->getData());
+        $this->assertSame($data, $mark_b->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_data()
+    {
+        $type = 'mark_a';
+        $data_a = ['data' => 'a'];
+        $data_b = ['data' => 'b'];
+
+        $mark_a = new Mark($type, $data_a);
+        $mark_b = $mark_a->withData($data_b);
+
+        $this->assertNotSame($mark_a, $mark_b);
+        $this->assertSame($type, $mark_a->getType());
+        $this->assertSame($type, $mark_b->getType());
+        $this->assertSame($data_a, $mark_a->getData());
+        $this->assertSame($data_b, $mark_b->getData());
+    }
+}

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -1,0 +1,24 @@
+<?php
+namespace Prezly\Slate\Tests;
+
+use Prezly\Slate\Model\Leaf;
+use Prezly\Slate\Model\Text;
+
+class TextTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_leaves()
+    {
+        $leaves_a = [new Leaf('a')];
+        $leaves_b = [new Leaf('b')];
+
+        $text_a = new Text($leaves_a);
+        $text_b = $text_a->withLeaves($leaves_b);
+
+        $this->assertNotSame($text_a, $text_b);
+        $this->assertSame($leaves_a, $text_a->getLeaves());
+        $this->assertSame($leaves_b, $text_b->getLeaves());
+    }
+}

--- a/tests/ValueTest.php
+++ b/tests/ValueTest.php
@@ -2,6 +2,9 @@
 
 namespace Prezly\Slate\Tests;
 
+use Prezly\Slate\Model\Document;
+use Prezly\Slate\Model\Value;
+
 class ValueTest extends TestCase
 {
     /**
@@ -22,6 +25,22 @@ class ValueTest extends TestCase
         );
 
         $this->assertEquals(trim($json), $value->toJson(JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_immutably_set_document()
+    {
+        $document_a = new Document();
+        $document_b = new Document();
+
+        $value_a = new Value($document_a);
+        $value_b = $value_a->withDocument($document_b);
+
+        $this->assertNotSame($value_a, $value_b);
+        $this->assertSame($document_a, $value_a->getDocument());
+        $this->assertSame($document_b, $value_b->getDocument());
     }
 
     public function fixtures(): array


### PR DESCRIPTION
As initially suggested in #19 

- Implement immutable setters for model properties
  - `Value::withDocument()`
  - `Document::withData()`
  - `Document::withNodes()`
  - `Block::withType()`
  - `Block::withData()`
  - `Block::withNodes()`
  - `Text::withLeaves()`
  - `Inline::withType()`
  - `Inline::withData()`
  - `Inline::withNodes()`
  - `Mark::withType()`
  - `Mark::withData()`
  - `Leaf::withText()`
  - `Leaf::withMarks()`
  - `Leaf::withMarks()`
- Deprecated old mutable setters (will be dropped in the next version)
  - `Value::setDocument()`
  - `Document::setData()`
  - `Document::addNode()`
  - `Block::setType()`
  - `Block::setData()`
  - `Block::addNode()`
  - `Text::addLeaf()`
  - `Inline::setType()`
  - `Inline::setData()`
  - `Inline::addNode()`
  - `Mark::setType()`
  - `Mark::setData()`
  - `Leaf::setText()`
  - `Leaf::setMarks()`
  - `Leaf::addMarks()`
- Add PHPDocs to every getter/setter method
